### PR TITLE
Add Docker setup for CadQuery Jupyter Notebook

### DIFF
--- a/notebooks/main.ipynb
+++ b/notebooks/main.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f8735f07-d949-49e6-99dd-997e9cabd1e9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Overwriting auto display for cadquery Workplane and Shape\n",
+      "\n",
+      "Enabling jupyter_cadquery replay\n",
+      "\n",
+      "Versions:\n",
+      "- jupyter_cadquery  3.5.2\n",
+      "- cad_viewer_widget 1.4.1\n",
+      "- open cascade      7.6.3\n",
+      "\n",
+      "Plugins loaded:\n",
+      "- cadquery-massembly\n"
+     ]
+    }
+   ],
+   "source": [
+    "import cadquery as cq\n",
+    "\n",
+    "from jupyter_cadquery import (\n",
+    "    versions,\n",
+    "    show, PartGroup, Part, \n",
+    "    get_viewer, close_viewer, get_viewers, close_viewers, open_viewer, set_defaults, get_defaults, open_viewer,\n",
+    "    get_pick,\n",
+    ")\n",
+    "\n",
+    "from jupyter_cadquery.replay import replay, enable_replay, disable_replay\n",
+    "''\n",
+    "enable_replay(False)\n",
+    "\n",
+    "set_defaults(\n",
+    "    cad_width=640, \n",
+    "    height=480, \n",
+    ")\n",
+    "\n",
+    "versions()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This commit introduces a Dockerfile and `docker_tests.sh` to facilitate
the deployment of CadQuery within Jupyter Notebooks. The Docker
image is configured to run Jupyter Lab, allowing immediate access to CadQuery
from Jupyter notebooks with minimal setup required. This commit includes
updates to documentation and the `docker_tests.sh` script to reflect the
change to a Docker-based workflow.

- `docker_tests.sh` allows for testing the functionality of the CadQuery docker.
- `README.md` has detailed information on how to setup the docker container